### PR TITLE
group routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 .settings
 .project
 .classpath
+
+.idea/
+*.iml

--- a/blade-core/pom.xml
+++ b/blade-core/pom.xml
@@ -22,6 +22,7 @@
 		<velocity.version>1.7</velocity.version>
 		<httpclient.version>4.3.5</httpclient.version>
 		<slf4j.version>1.7.7</slf4j.version>
+		<junit.version>4.12</junit.version>
 	</properties>
 
 	<dependencies>
@@ -72,6 +73,11 @@
 			<version>${jetty.version}</version>
 			<scope>provided</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/blade-core/src/main/java/com/blade/Blade.java
+++ b/blade-core/src/main/java/com/blade/Blade.java
@@ -359,7 +359,7 @@ public class Blade {
 
 
 	public Blade group(String path, RouteGroup group) {
-		group.merge(path, this);
+		group.index(path, this);
 		return this;
 	}
 	

--- a/blade-core/src/main/java/com/blade/Blade.java
+++ b/blade-core/src/main/java/com/blade/Blade.java
@@ -15,17 +15,10 @@
  */
 package com.blade;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.ParseException;
-import java.util.List;
-import java.util.Map;
-
 import blade.kit.Assert;
 import blade.kit.IOKit;
 import blade.kit.PropertyKit;
 import blade.kit.json.JSONKit;
-
 import com.blade.ioc.Container;
 import com.blade.ioc.SampleContainer;
 import com.blade.loader.ClassPathRouteLoader;
@@ -34,12 +27,15 @@ import com.blade.loader.Configurator;
 import com.blade.plugin.Plugin;
 import com.blade.render.JspRender;
 import com.blade.render.Render;
-import com.blade.route.Route;
-import com.blade.route.RouteException;
-import com.blade.route.RouteHandler;
-import com.blade.route.Routers;
+import com.blade.route.*;
 import com.blade.server.Server;
 import com.blade.web.http.HttpMethod;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Blade Core Class
@@ -316,7 +312,7 @@ public class Blade {
      * Add a route
      * 
      * @param path			route path
-     * @param target		Target object for routing
+     * @param clazz			The class for routing
      * @param method		The method name of the route (at the same time, the HttpMethod is specified: post:saveUser, if not specified, HttpMethod.ALL)
      * @return				return blade
      */
@@ -358,6 +354,12 @@ public class Blade {
 	 */
 	public Blade get(String path, RouteHandler handler){
 		routers.route(path, handler, HttpMethod.GET);
+		return this;
+	}
+
+
+	public Blade group(String path, RouteGroup group) {
+		group.merge(path, this);
 		return this;
 	}
 	

--- a/blade-core/src/main/java/com/blade/route/RouteGroup.java
+++ b/blade-core/src/main/java/com/blade/route/RouteGroup.java
@@ -51,27 +51,36 @@ public abstract class RouteGroup {
         blade.put(formatPath(prefix, path), handler);
     }
 
+    public void group(String path, RouteGroup group) {
+        group.index(formatPath(this.prefix, path), this.blade);
+    }
+
     public abstract void route();
 
-    public void merge(String path, Blade blade) {
+    public void index(String path, Blade blade) {
         this.prefix = path;
         this.blade = blade;
         route();
     }
 
     public static String formatPath(String prefix, String path) {
+        String routePath;
         if (prefix.endsWith("/")) {
             if (path.startsWith("/")) {
-                return prefix + path.substring(1);
+                routePath = prefix + path.substring(1);
             } else {
-                return prefix + path;
+                routePath = prefix + path;
             }
         } else {
             if (path.startsWith("/")) {
-                return prefix + path;
+                routePath = prefix + path;
             } else {
-                return prefix + "/" + path;
+                routePath = prefix + "/" + path;
             }
         }
+        if (routePath.endsWith("/")) {
+            return routePath.substring(0, routePath.length() - 1);
+        }
+        return routePath;
     }
 }

--- a/blade-core/src/main/java/com/blade/route/RouteGroup.java
+++ b/blade-core/src/main/java/com/blade/route/RouteGroup.java
@@ -1,0 +1,77 @@
+package com.blade.route;
+
+import com.blade.Blade;
+
+/**
+ * @author XieEnlong
+ * @date 2016/1/26.
+ */
+public abstract class RouteGroup {
+
+    private String prefix;
+
+    private Blade blade;
+
+    /**
+     * Register a GET request route
+     * @param path		route path, request url
+     * @param handler	execute route Handle
+     */
+    public void get(String path, RouteHandler handler) {
+        blade.get(formatPath(prefix, path), handler);
+    }
+
+    /**
+     * Register a POST request route
+     *
+     * @param path		route path, request url
+     * @param handler	execute route Handle
+     */
+    public void post(String path, RouteHandler handler){
+        blade.post(formatPath(prefix, path), handler);
+    }
+
+    /**
+     * Register a DELETE request route
+     *
+     * @param path		route path, request url
+     * @param handler	execute route Handle
+     */
+    public void delete(String path, RouteHandler handler){
+        blade.delete(formatPath(prefix, path), handler);
+    }
+
+    /**
+     * Register a PUT request route
+     *
+     * @param path		route path, request url
+     * @param handler	execute route Handle
+     */
+    public void put(String path, RouteHandler handler){
+        blade.put(formatPath(prefix, path), handler);
+    }
+
+    public abstract void route();
+
+    public void merge(String path, Blade blade) {
+        this.prefix = path;
+        this.blade = blade;
+        route();
+    }
+
+    public static String formatPath(String prefix, String path) {
+        if (prefix.endsWith("/")) {
+            if (path.startsWith("/")) {
+                return prefix + path.substring(1);
+            } else {
+                return prefix + path;
+            }
+        } else {
+            if (path.startsWith("/")) {
+                return prefix + path;
+            } else {
+                return prefix + "/" + path;
+            }
+        }
+    }
+}

--- a/blade-core/src/test/java/com.blade/GroupTest.java
+++ b/blade-core/src/test/java/com.blade/GroupTest.java
@@ -1,0 +1,77 @@
+package com.blade;
+
+import com.blade.route.RouteGroup;
+import com.blade.route.RouteHandler;
+import com.blade.web.http.Request;
+import com.blade.web.http.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author xieenlong
+ * @date 16/1/26.
+ */
+public class GroupTest {
+
+    @Test
+    public void nestedGroup() {
+        Blade blade = Blade.me();
+        blade.group("/", new RouteGroup() {
+            @Override
+            public void route() {
+                get("posts", new RouteHandler() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.html("all posts");
+                    }
+                });
+
+                group("users", new RouteGroup() {
+                    @Override
+                    public void route() {
+                        get("", new RouteHandler() {
+                            @Override
+                            public void handle(Request request, Response response) {
+                                response.html("all users");
+                            }
+                        });
+
+                        group(":userId/posts", new RouteGroup() {
+                            @Override
+                            public void route() {
+                                get("", new RouteHandler() {
+                                    @Override
+                                    public void handle(Request request, Response response) {
+                                        response.html("user " + request.param("userId") + "'s all posts");
+                                    }
+                                });
+
+                                get(":postId", new RouteHandler() {
+                                    @Override
+                                    public void handle(Request request, Response response) {
+                                        response.html("user " + request.param("userId") + "'s post " + request.param("postId"));
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        });
+        List<String> keys = Arrays.asList("/users/:userId/posts#GET", "/users#GET", "/posts#GET", "/users/:userId/posts/:postId#GET");
+        Assert.assertEquals(blade.routers().getRoutes().size(), 4);
+        Assert.assertTrue(blade.routers().getRoutes().keySet().containsAll(keys));
+    }
+
+    @Test
+    public void nestedGroupConfig() {
+        Blade blade = Blade.me();
+        blade.routeConf("com.blade.controllers", "route.conf");
+        List<String> keys = Arrays.asList("/users/:userId/posts#GET", "/users#GET", "/posts#GET", "/users/:userId/posts/:postId#GET");
+        Assert.assertEquals(blade.routers().getRoutes().size(), 4);
+        Assert.assertTrue(blade.routers().getRoutes().keySet().containsAll(keys));
+    }
+}

--- a/blade-core/src/test/java/com.blade/controllers/PostController.java
+++ b/blade-core/src/test/java/com.blade/controllers/PostController.java
@@ -1,0 +1,23 @@
+package com.blade.controllers;
+
+import com.blade.web.http.Request;
+import com.blade.web.http.Response;
+
+/**
+ * @author xieenlong
+ * @date 16/1/26.
+ */
+public class PostController {
+
+    public void all(Request request, Response response) {
+        response.html("all posts");
+    }
+
+    public void byAuthor(Request request, Response response) {
+        response.html("user " + request.param("userId") + "'s all posts");
+    }
+
+    public void get(Request request, Response response) {
+        response.html("user " + request.param("userId") + "'s post " + request.param("postId"));
+    }
+}

--- a/blade-core/src/test/java/com.blade/controllers/UserController.java
+++ b/blade-core/src/test/java/com.blade/controllers/UserController.java
@@ -1,0 +1,15 @@
+package com.blade.controllers;
+
+import com.blade.web.http.Request;
+import com.blade.web.http.Response;
+
+/**
+ * @author xieenlong
+ * @date 16/1/26.
+ */
+public class UserController {
+
+    public void all(Request request, Response response) {
+        response.html("all users");
+    }
+}

--- a/blade-core/src/test/resources/route.conf
+++ b/blade-core/src/test/resources/route.conf
@@ -1,0 +1,10 @@
+GROUP               /               UserController
+    GET             posts           PostController.all
+    GROUP           users
+        GET         /               all
+        GROUP       :userId/posts   PostController
+            GET     /               byAuthor
+            GET     /:postId        get
+        END
+    END
+END


### PR DESCRIPTION
简单的实现了一下namespace的分组路由，包含blade.group方法和配置文件，支持嵌套分组，添加了两个简单的测试用例。

不过配置文件解析那里由于引入了分组导致代码有些混乱，可能还需要再小改一下。
