### PR TITLE
#85 [new feature] Enable auto/hot refresh for template/static files

### DIFF
--- a/src/main/java/com/blade/kit/reload/FileChangeDetector.java
+++ b/src/main/java/com/blade/kit/reload/FileChangeDetector.java
@@ -1,0 +1,85 @@
+package com.blade.kit.reload;
+
+import com.blade.Environment;
+import com.blade.mvc.Const;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Eddie Wang on 12/25/17.
+ */
+@Slf4j
+public class FileChangeDetector {
+    private WatchService watcher;
+    private Map<WatchKey, Path> pathMap = new HashMap<>();
+
+    public FileChangeDetector(String dirPath) throws IOException{
+        watcher = FileSystems.getDefault().newWatchService();
+        registerAll(Paths.get(dirPath));
+    }
+
+    private void register(Path dir) throws IOException{
+        WatchKey key = dir.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
+        pathMap.put(key,dir);
+    }
+
+    private void registerAll(Path dir) throws  IOException{
+        Files.walkFileTree(dir, new SimpleFileVisitor<Path>(){
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                register(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    public void processEvent(BiConsumer<WatchEvent.Kind<Path>, Path> processor){
+        for(;;){
+            WatchKey key;
+            try{
+                key = watcher.take();
+            }catch (InterruptedException e) {
+                return;
+            }
+
+            Path dir = pathMap.get(key);
+            for (WatchEvent<?> event: key.pollEvents()){
+                WatchEvent.Kind kind = event.kind();
+                Path filePath = dir.resolve(((WatchEvent<Path>)event).context());
+
+                if(Files.isDirectory(filePath)) continue;
+                log.info("File {} changes detected!",filePath.toString());
+                //copy updated files to target
+                processor.accept(kind, filePath);
+            }
+            key.reset();
+        }
+    }
+
+    public static Path getDestPath(Path src, Environment env){
+        String templateDir = env.get(Const.ENV_KEY_TEMPLATE_PATH,"/templates");
+        Optional<String> staticDir =  env.get(Const.ENV_KEY_STATIC_DIRS);
+        List<String> templateOrStaticDirKeyword = new ArrayList<>();
+        templateOrStaticDirKeyword.add(templateDir);
+        if(staticDir.isPresent()){
+            templateOrStaticDirKeyword.addAll(Arrays.asList(staticDir.get().split(",")));
+        }else{
+            templateOrStaticDirKeyword.addAll(Const.DEFAULT_STATICS);
+        }
+
+        List result = templateOrStaticDirKeyword.stream().filter(dir -> src.toString().indexOf(dir)!=-1).collect(Collectors.toList());
+        if(result.size()!=1){
+            log.info("Cannot get dest dir");
+            return  null;
+        }
+        String key = (String)result.get(0);
+        log.info(Const.CLASSPATH + src.toString().substring(src.toString().indexOf(key)));
+        return Paths.get(Const.CLASSPATH + src.toString().substring(src.toString().indexOf(key)));
+    }
+}

--- a/src/main/java/com/blade/mvc/Const.java
+++ b/src/main/java/com/blade/mvc/Const.java
@@ -70,7 +70,7 @@ public interface Const {
     String ENV_KEY_NETTY_SO_BACKLOG          = "server.netty.so-backlog";
 
     String ENV_KEY_BOOT_CONF = "boot_conf";
-
+    String ENV_KEY_AUTO_REFRESH_DIR        = "app.auto.refresh.dir";
     // terminal
     String TERMINAL_SERVER_ADDRESS = "--server.address=";
     String TERMINAL_SERVER_PORT    = "--server.port=";

--- a/src/main/java/com/blade/server/netty/NettyServer.java
+++ b/src/main/java/com/blade/server/netty/NettyServer.java
@@ -77,7 +77,6 @@ public class NettyServer implements Server {
         log.info("Environment: file.encoding  => {}", System.getProperty("file.encoding"));
         log.info("Environment: classpath      => {}", CLASSPATH);
 
-        this.loadConfig(args);
         this.initConfig();
 
         WebContext.init(blade, "/");
@@ -229,46 +228,6 @@ public class NettyServer implements Server {
             Thread t = new Thread(new EnvironmentWatcher());
             t.setName("watch@thread");
             t.start();
-        }
-    }
-
-    private void loadConfig(String[] args) {
-
-        String bootConf = blade.environment().get(ENV_KEY_BOOT_CONF, "classpath:app.properties");
-
-        Environment bootEnv = Environment.of(bootConf);
-
-        if (bootEnv != null) {
-            bootEnv.props().forEach((key, value) -> environment.set(key.toString(), value));
-        }
-
-        if (null != args) {
-            Optional<String> envArg = Stream.of(args).filter(s -> s.startsWith(Const.TERMINAL_BLADE_ENV)).findFirst();
-            envArg.ifPresent(arg -> {
-                String envName = "app-" + arg.split("=")[1] + ".properties";
-                log.info("current environment file is: {}", envName);
-                Environment customEnv = Environment.of(envName);
-                if (customEnv != null) {
-                    customEnv.props().forEach((key, value) -> environment.set(key.toString(), value));
-                }
-            });
-        }
-
-        blade.register(environment);
-
-        // load terminal param
-        if (!BladeKit.isEmpty(args)) {
-            for (String arg : args) {
-                if (arg.startsWith(TERMINAL_SERVER_ADDRESS)) {
-                    int    pos     = arg.indexOf(TERMINAL_SERVER_ADDRESS) + TERMINAL_SERVER_ADDRESS.length();
-                    String address = arg.substring(pos);
-                    environment.set(ENV_KEY_SERVER_ADDRESS, address);
-                } else if (arg.startsWith(TERMINAL_SERVER_PORT)) {
-                    int    pos  = arg.indexOf(TERMINAL_SERVER_PORT) + TERMINAL_SERVER_PORT.length();
-                    String port = arg.substring(pos);
-                    environment.set(ENV_KEY_SERVER_PORT, port);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
#85

This merge will add auto refresh feature for blade with limitation for template and static files.

How to use?

First of all, this feature only works in DEV MODE.
Second, customer need to specify the dir location in the `app.properties`, like

```bash
server.port=9005
app.version=0.0.2
jdbc.url=jdbc:mysql://127.0.0.1:3306/test
app.users=301
app.maxMoney=38.1
app.sex=true
app.hits=199283818033
app.startDate=2017-08-02
app.auto.refresh.dir=/Users/Eddie/Documents/GitHub/blade/src/test/resources
```

In this case, all the static files and template files located under subdir of resources. (Default setting in intellij).

What test did i run?

I am testing using `io.example.blog` package.
I can see new html pages returned after i make changes on my IDE without restart server