### PR TITLE
use varargs in StringKit.isNotBlank()

### DIFF
--- a/src/main/java/com/blade/kit/StringKit.java
+++ b/src/main/java/com/blade/kit/StringKit.java
@@ -45,14 +45,20 @@ public final class StringKit {
         return num.toString();
     }
 
+
     /**
-     * Determine whether a string is not blank
-     *
-     * @param str string value
-     * @return return string is not blank
+     * Determine whether a list of string is not blank
+     * @param str a list of string value
+     * @return return any one in this list of string is not blank
      */
-    public static boolean isNotBlank(String str) {
-        return null != str && !"".equals(str.trim());
+    public static boolean isNotBlank(String... str){
+        if (str == null) return false;
+        for (String s : str){
+            if (isBlank(s)){
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/com/blade/kit/StringKitTest.java
+++ b/src/test/java/com/blade/kit/StringKitTest.java
@@ -22,6 +22,14 @@ public class StringKitTest {
 
         Assert.assertEquals(false, StringKit.isNotBlank(""));
         Assert.assertEquals(false, StringKit.isNotBlank(null));
+
+
+        Assert.assertEquals(false,StringKit.isNotBlank("a","b","  "));
+        Assert.assertEquals(false,StringKit.isNotBlank("a","b",null));
+
+        Assert.assertEquals(true,StringKit.isNotBlank("a","b","c"));
+        Assert.assertEquals(true,StringKit.isNotBlank("abc","d ef","gh i"));
+
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for contributing to Blade. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
when a method have a long param list we can avoid to write code like this:
`StringKit.isNotBlank(a) && StringKit.isNotBlank(b) &&...`