### PR TITLE
Fixed very tiny typo in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ curl -X POST http://127.0.0.1:9000/body -d '{"username":"biezhi","age":22}'
 
 ```java
 Environment environment = WebContext.blade().environment();
-String version = environment.get("app.version", "0.0.1");;
+String version = environment.get("app.version", "0.0.1");
 ```
 
 ## Get Header

--- a/README_CN.md
+++ b/README_CN.md
@@ -308,7 +308,7 @@ curl -X POST http://127.0.0.1:9000/body -d '{"username":"biezhi","age":22}'
 
 ```java
 Environment environment = WebContext.blade().environment();
-String version = environment.get("app.version", "0.0.1");;
+String version = environment.get("app.version", "0.0.1");
 ```
 
 ## 获取 Header


### PR DESCRIPTION
This pull requests addresses very tiny typo i've notice in the README.md
Removed extra semicolon in one of the examples