### PR TITLE
fix: Fix StaticFileHandle cannot found static files with Gradle

### DIFF
--- a/src/main/java/com/blade/server/netty/StaticFileHandler.java
+++ b/src/main/java/com/blade/server/netty/StaticFileHandler.java
@@ -135,7 +135,7 @@ public class StaticFileHandler implements RequestHandler {
             // gradle resources path
             File resourcesDirectory = new File(new File(Const.class.getResource("/").getPath()).getParent() + "/resources");
             if (resourcesDirectory.isDirectory()) {
-                file = new File(resourcesDirectory.getPath() + "/resources/" + cleanUri.substring(1));
+              file = new File(resourcesDirectory.getPath() + "/" + cleanUri.substring(1));
                 if (file.isHidden() || !file.exists()) {
                     log404(log, method, uri);
                     throw new NotFoundException(uri);


### PR DESCRIPTION
#248 Fix StaticFileHandle cannot found static files with Gradle & IntelliJ IDEA
Is already be tested, it worked on Jar or IDEA.

Test Environment:
OS: OS X 10.14.1 Mojave
Gradle: Gradle 4.10.2
JDK: Oracle JDK 1.8.0_162
IDE: IntelliJ IDEA 2018.3
