### PR TITLE
add @OnOpen/@OnMessage/@OnClose supported

### DIFF
--- a/src/main/java/com/blade/mvc/annotation/OnClose.java
+++ b/src/main/java/com/blade/mvc/annotation/OnClose.java
@@ -1,0 +1,14 @@
+package com.blade.mvc.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author darren
+ * @description invoke websocketHandler onDisConnect method
+ * @date 2018/12/17 18:41
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OnClose {
+}

--- a/src/main/java/com/blade/mvc/annotation/OnMessage.java
+++ b/src/main/java/com/blade/mvc/annotation/OnMessage.java
@@ -1,0 +1,14 @@
+package com.blade.mvc.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author darren
+ * @description invoke websocketHandler onText method
+ * @date 2018/12/17 18:41
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OnMessage {
+}

--- a/src/main/java/com/blade/mvc/annotation/OnOpen.java
+++ b/src/main/java/com/blade/mvc/annotation/OnOpen.java
@@ -1,0 +1,14 @@
+package com.blade.mvc.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author darren
+ * @description invoke websocketHandler onConnect method
+ * @date 2018/12/17 18:41
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OnOpen {
+}

--- a/src/main/java/com/blade/mvc/annotation/WebSocket.java
+++ b/src/main/java/com/blade/mvc/annotation/WebSocket.java
@@ -17,15 +17,15 @@ import java.lang.annotation.Target;
 @Documented
 @Bean
 public @interface WebSocket {
-    /**
-     * alias for path
-     * @return
-     */
-    String[] value() default {};
 
     /**
-     * websocket path
-     * @return
+     * @return websocket path
      */
-    String[] path() default {};
+    String value() default "/websocket";
+
+
+    /**
+     * @return websocket description
+     */
+    String description() default "";
 }

--- a/src/main/java/com/blade/mvc/handler/WebSocketHandlerWrapper.java
+++ b/src/main/java/com/blade/mvc/handler/WebSocketHandlerWrapper.java
@@ -1,0 +1,125 @@
+package com.blade.mvc.handler;
+
+import com.blade.Blade;
+import com.blade.kit.ReflectKit;
+import com.blade.mvc.annotation.OnClose;
+import com.blade.mvc.annotation.OnMessage;
+import com.blade.mvc.annotation.OnOpen;
+import com.blade.mvc.websocket.WebSocketContext;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author darren
+ * @description
+ * @date 2018/12/17 18:41
+ */
+@Slf4j
+public final class WebSocketHandlerWrapper implements WebSocketHandler {
+
+    private final Map<String,Class<?>> handlers = new HashMap<>(4);
+    private final Map<String, Map<Class<? extends Annotation>, Method>> methodCache = new HashMap<>(4);
+    private final ThreadLocal<String> path = ThreadLocal.withInitial(() -> null);
+    private final Blade blade;
+
+    public static WebSocketHandlerWrapper init(Blade blade) {
+        return new WebSocketHandlerWrapper(blade);
+    }
+
+    private WebSocketHandlerWrapper(Blade blade) {
+        this.blade = blade;
+    }
+
+    public void setPath(String path) {
+        this.path.set(path);
+    }
+
+    /**
+     * add @WebSocket handler mapper
+     *
+     * @param path
+     * @param handler
+     */
+    public void wrapHandler(String path, Class<?> handler) {
+        Method[] methods = handler.getMethods();
+        Map<Class<? extends Annotation>, Method> cache = new HashMap<>(3);
+        cacheMethod(cache, methods, OnOpen.class);
+        cacheMethod(cache, methods, OnMessage.class);
+        cacheMethod(cache, methods, OnClose.class);
+        if (cache.size() > 0) {
+            methodCache.put(path, cache);
+            handlers.put(path,handler);
+        } else {
+            throw new RuntimeException("Do not found any annotation of [@OnOpen / @OnMessage / @OnClose] in class: " + handler.getName());
+        }
+    }
+
+    private static void cacheMethod(Map<Class<? extends Annotation>, Method> cache, Method[] methods, Class<? extends Annotation> filter) {
+        List<Method> methodList = Stream.of(methods)
+                .filter(method -> method.isAnnotationPresent(filter))
+                .collect(Collectors.toList());
+        if (methodList.size() == 1) {
+            cache.put(filter, methodList.get(0));
+        } else if (methodList.size() > 1) {
+            throw new RuntimeException("Duplicate annotation @" + filter.getSimpleName() + " in class: " + methodList.get(0).getDeclaringClass().getName());
+        }
+    }
+
+    @Override
+    public void onConnect(WebSocketContext ctx) {
+        invoke(ctx, OnOpen.class);
+    }
+
+    @Override
+    public void onText(WebSocketContext ctx) {
+        invoke(ctx, OnMessage.class);
+    }
+
+    @Override
+    public void onDisConnect(WebSocketContext ctx) {
+        invoke(ctx, OnClose.class);
+    }
+
+    /**
+     * invoke target handler methods
+     *
+     * @param ctx   WebSocket context
+     * @param event WebSocket event type
+     */
+    private void invoke(WebSocketContext ctx, Class<? extends Annotation> event) {
+        Map<Class<? extends Annotation>, Method> methodCache = this.methodCache.get(path.get());
+        if (methodCache != null) {
+            Method method = methodCache.get(event);
+            if (method != null) {
+                Class<?>[] paramTypes = method.getParameterTypes();
+                Object[] param = new Object[paramTypes.length];
+                try {
+                    for (int i = 0; i < paramTypes.length; i++) {
+                        Class<?> paramType = paramTypes[i];
+                        if (paramType == WebSocketContext.class) {
+                            param[i] = ctx;
+                        } else {
+                            Object bean = this.blade.getBean(paramType);
+                            if (bean != null) {
+                                param[i] = bean;
+                            } else {
+                                param[i] = ReflectKit.newInstance(paramType);
+                            }
+                        }
+                    }
+                    method.invoke(blade.getBean(handlers.get(path.get())), param);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/netty_hello/BaseWebSocketHandler.java
+++ b/src/test/java/netty_hello/BaseWebSocketHandler.java
@@ -1,0 +1,24 @@
+package netty_hello;
+
+import com.blade.mvc.annotation.OnClose;
+import com.blade.mvc.annotation.OnOpen;
+import com.blade.mvc.websocket.WebSocketContext;
+
+/**
+ * @author darren
+ * @description
+ * @date 2018/12/18 13:29
+ */
+public abstract class BaseWebSocketHandler {
+
+
+    @OnOpen
+    public void OnOpen(WebSocketContext ctx) {
+        System.out.println("ws from annotation @OnOpen:" + ctx.getSession().getUuid());
+    }
+
+    @OnClose
+    public void OnClose(WebSocketContext ctx) {
+        System.out.println("ws from annotation @OnClose:" + ctx.getSession().getUuid() + " disconnect");
+    }
+}

--- a/src/test/java/netty_hello/CustomWebSocketHandler.java
+++ b/src/test/java/netty_hello/CustomWebSocketHandler.java
@@ -1,5 +1,6 @@
 package netty_hello;
 
+import com.blade.ioc.annotation.Inject;
 import com.blade.mvc.annotation.WebSocket;
 import com.blade.mvc.handler.WebSocketHandler;
 import com.blade.mvc.websocket.WebSocketContext;
@@ -8,20 +9,25 @@ import com.blade.mvc.websocket.WebSocketContext;
  * @author darren
  * @date 2018-12-10 21:27
  */
-@WebSocket(value="/websocket_anno_value",path = {"/websocket_anno_path","/websocket_anno_value"})
+@WebSocket("/ws_impl")
 public class CustomWebSocketHandler implements WebSocketHandler {
+
+    @Inject
+    CService cService;
+
     @Override
     public void onConnect(WebSocketContext ctx) {
-        System.out.println("connect success:session="+ctx.getSession().getUuid());
+        cService.sayHello();
+        System.out.println("ws from implements interface:onConnect:"+ctx.getSession().getUuid());
     }
 
     @Override
     public void onText(WebSocketContext ctx) {
-        System.out.println(ctx.getSession().getUuid() + " said:" + ctx.getReqText());
+        System.out.println("ws from implements interface:onText:"+ctx.getSession().getUuid() + " said:" + ctx.getReqText());
     }
 
     @Override
     public void onDisConnect(WebSocketContext ctx) {
-        System.out.println(ctx.getSession().getUuid() + " disconnect");
+        System.out.println("ws from implements interface:onDisConnect:"+ctx.getSession().getUuid() + " disconnect");
     }
 }

--- a/src/test/java/netty_hello/CustomWebSocketHandlerAnno.java
+++ b/src/test/java/netty_hello/CustomWebSocketHandlerAnno.java
@@ -1,0 +1,19 @@
+package netty_hello;
+
+import com.blade.mvc.annotation.OnMessage;
+import com.blade.mvc.annotation.WebSocket;
+import com.blade.mvc.websocket.WebSocketContext;
+
+/**
+ * @author darren
+ * @description
+ * @date 2018/12/18 11:01
+ */
+@WebSocket("/ws_anno")
+public class CustomWebSocketHandlerAnno extends BaseWebSocketHandler {
+
+    @OnMessage
+    public void OnMessage(WebSocketContext ctx) {
+        System.out.println("ws from annotation @OnMessage:" + ctx.getSession().getUuid() + " said:" + ctx.getReqText());
+    }
+}

--- a/src/test/java/netty_hello/WebSocketDemo.java
+++ b/src/test/java/netty_hello/WebSocketDemo.java
@@ -29,23 +29,6 @@ public class WebSocketDemo {
                     public void onDisConnect(WebSocketContext ctx) {
                         System.out.println("ws1客户端关闭链接: " + ctx.getSession());
                     }
-                })
-                .webSocket("/websocket2", new WebSocketHandler() {
-                    @Override
-                    public void onConnect(WebSocketContext ctx) {
-                        System.out.println("客户端连接上了ws2: " + ctx.getSession());
-                    }
-
-                    @Override
-                    public void onText(WebSocketContext ctx) {
-                        System.out.println("ws2收到:" + ctx.getReqText());
-                        ctx.message("发送: Hello");
-                    }
-
-                    @Override
-                    public void onDisConnect(WebSocketContext ctx) {
-                        System.out.println("ws2客户端关闭链接: " + ctx.getSession());
-                    }
                 }).start(WebSocketDemo.class);
     }
 


### PR DESCRIPTION
为`@WebSocket`添加 `@OnOpen`/`@OnMessage`/`@OnClose` 支持
---
目前blade支持三种方式来实现对WebSocket的支持
- 方式一：函数式编程
~~~java
Blade.of().webSocket("/websocket", new WebSocketHandler() {
    @Override
    public void onConnect(WebSocketContext ctx) {}

    @Override
    public void onText(WebSocketContext ctx) {}

    @Override
    public void onDisConnect(WebSocketContext ctx) {}
}).start();
~~~

- 方式二：使用 `@WebSocket` 注解并实现 `WebSocketHandler` 接口
~~~java
@WebSocket("/websocket")
public class CustomWebSocketHandler implements WebSocketHandler {
    @Override
    public void onConnect(WebSocketContext ctx) {}

    @Override
    public void onText(WebSocketContext ctx) {}

    @Override
    public void onDisConnect(WebSocketContext ctx) {}
}
~~~

- 方式三：使用 `@WebSocket` 注解 配合  `@OnOpen`/`@OnMessage`/`@OnClose`  注解（类似于javax）
~~~java
@WebSocket("/websocket")
public class CustomWebSocketHandler{
    @OnOpen
    public void myConnectMethod(WebSocketContext ctx) {}

    @OnMessage
    public void myMessageMethod(WebSocketContext ctx) {}

    @OnClose
    public void myCloseMethod(WebSocketContext ctx) {}
}
~~~
> 方式二与方式三的区别在于 方式二 需要实现一个接口，且必须得实现三个方法，方式三不需要实现接口更灵活，比如允许只实现原本三个方法中的一个或两个方法