### PR TITLE
improve the default template engine

### DIFF
--- a/src/main/java/com/blade/kit/IOKit.java
+++ b/src/main/java/com/blade/kit/IOKit.java
@@ -53,17 +53,17 @@ public class IOKit {
     }
 
     public static String readToString(BufferedReader bufferedReader) {
-        return bufferedReader.lines().collect(Collectors.joining());
+        return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
     }
 
     public static String readToString(Path path) throws IOException {
         BufferedReader bufferedReader = Files.newBufferedReader(path);
-        return bufferedReader.lines().collect(Collectors.joining());
+        return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
     }
 
     public static String readToString(InputStream input) throws IOException {
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input, "UTF-8"))) {
-            return buffer.lines().collect(Collectors.joining("\n"));
+            return buffer.lines().collect(Collectors.joining(System.lineSeparator()));
         }
     }
 


### PR DESCRIPTION
改进默认的模板引擎
当前blade-mvc自带的DefaultEngine有个问题，就是会将所有的html字符压缩成一行显示。
这样当遇到类似于下面的html片段：
~~~html
<script>
function fn(){
    /* ps：下面一行加了双斜杠的注释 */
    var a = 1;// comment...  
    var b = 2;
    /* ps: 下面一行语句后面没加分号（js默认是允许的）*/
    console.log(a+b) 
    return a + b;
}
</script>
~~~
导致压缩成一行的时候，行注释会将后面所有的代码都注释，不加分号的地方 也会和后面的代码块混为一起导致语法错误。所以不知道是当时写的时候遗漏了导致的bug还是当时没考虑到此种情况，目前是统一都加上了换行符，改动点如下：
~~~java
    //IOKit
    public static String readToString(BufferedReader bufferedReader) {
        return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
    }

    public static String readToString(Path path) throws IOException {
        BufferedReader bufferedReader = Files.newBufferedReader(path);
        return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
    }
~~~