### PR TITLE
websocket bug修复和调整

### DIFF
--- a/src/main/java/com/blade/mvc/handler/WebSocketHandlerWrapper.java
+++ b/src/main/java/com/blade/mvc/handler/WebSocketHandlerWrapper.java
@@ -6,6 +6,7 @@ import com.blade.mvc.annotation.OnClose;
 import com.blade.mvc.annotation.OnMessage;
 import com.blade.mvc.annotation.OnOpen;
 import com.blade.mvc.websocket.WebSocketContext;
+import io.netty.util.concurrent.FastThreadLocal;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.annotation.Annotation;
@@ -27,7 +28,7 @@ public final class WebSocketHandlerWrapper implements WebSocketHandler {
 
     private final Map<String,Class<?>> handlers = new HashMap<>(4);
     private final Map<String, Map<Class<? extends Annotation>, Method>> methodCache = new HashMap<>(4);
-    private final ThreadLocal<String> path = ThreadLocal.withInitial(() -> null);
+    private final FastThreadLocal<String> path = new FastThreadLocal<>();
     private final Blade blade;
 
     public static WebSocketHandlerWrapper init(Blade blade) {

--- a/src/main/java/com/blade/mvc/websocket/WebSocketContext.java
+++ b/src/main/java/com/blade/mvc/websocket/WebSocketContext.java
@@ -1,27 +1,47 @@
 package com.blade.mvc.websocket;
 
-import io.netty.channel.ChannelHandlerContext;
+import com.blade.mvc.handler.WebSocketHandler;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import lombok.Data;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 /**
- * @author biezhi
+ * @author biezhi,darren
  * @date 2017/10/30
  */
-@Data
+@Accessors(fluent = true)
 public class WebSocketContext {
 
-    private ChannelHandlerContext ctx;
+    @Getter
     private WebSocketSession      session;
-    private String                reqText;
+    @Getter
+    private String                message;
+    private WebSocketHandler      handler;
 
-    public WebSocketContext(ChannelHandlerContext ctx) {
-        this.ctx = ctx;
-        this.session = new WebSocketSession(ctx.channel());
+    public WebSocketContext(WebSocketSession session,WebSocketHandler handler) {
+        this.session = session;
+        this.handler = handler;
+    }
+    public WebSocketContext(WebSocketSession session,WebSocketHandler handler,String message) {
+        this(session,handler);
+        this.message = message;
     }
 
+    /**
+     * post a message
+     * @param value
+     */
     public void message(String value) {
-        ctx.writeAndFlush(new TextWebSocketFrame(value));
+        session.handlerContext().writeAndFlush(new TextWebSocketFrame(value));
+    }
+
+    /**
+     * Allows the user to disconnect the websocket
+     */
+    public void disconnect(){
+        session.handlerContext().disconnect().addListener(ChannelFutureListener.CLOSE);
+        handler.onDisConnect(this);
     }
 
 }

--- a/src/main/java/com/blade/mvc/websocket/WebSocketSession.java
+++ b/src/main/java/com/blade/mvc/websocket/WebSocketSession.java
@@ -1,21 +1,23 @@
 package com.blade.mvc.websocket;
 
 import com.blade.kit.UUID;
-import io.netty.channel.Channel;
-import lombok.Data;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 /**
- * @author biezhi
+ * @author biezhi,darren
  * @date 2017/10/30
  */
-@Data
+@Getter
+@Accessors(fluent = true)
 public class WebSocketSession {
 
-    private Channel channel;
+    private ChannelHandlerContext handlerContext;
     private String uuid;
 
-    public WebSocketSession(Channel channel) {
-        this.channel = channel;
+    public WebSocketSession(ChannelHandlerContext handlerContext) {
+        this.handlerContext = handlerContext;
         this.uuid = UUID.UU32();
     }
 }

--- a/src/test/java/netty_hello/BaseWebSocketHandler.java
+++ b/src/test/java/netty_hello/BaseWebSocketHandler.java
@@ -14,11 +14,11 @@ public abstract class BaseWebSocketHandler {
 
     @OnOpen
     public void OnOpen(WebSocketContext ctx) {
-        System.out.println("ws from annotation @OnOpen:" + ctx.getSession().getUuid());
+        System.out.println("ws from annotation @OnOpen:" + ctx.session().uuid());
     }
 
     @OnClose
     public void OnClose(WebSocketContext ctx) {
-        System.out.println("ws from annotation @OnClose:" + ctx.getSession().getUuid() + " disconnect");
+        System.out.println("ws from annotation @OnClose:" + ctx.session().uuid() + " disconnect");
     }
 }

--- a/src/test/java/netty_hello/CustomWebSocketHandler.java
+++ b/src/test/java/netty_hello/CustomWebSocketHandler.java
@@ -18,16 +18,16 @@ public class CustomWebSocketHandler implements WebSocketHandler {
     @Override
     public void onConnect(WebSocketContext ctx) {
         cService.sayHello();
-        System.out.println("ws from implements interface:onConnect:"+ctx.getSession().getUuid());
+        System.out.println("ws from implements interface:onConnect:"+ctx.session().uuid());
     }
 
     @Override
     public void onText(WebSocketContext ctx) {
-        System.out.println("ws from implements interface:onText:"+ctx.getSession().getUuid() + " said:" + ctx.getReqText());
+        System.out.println("ws from implements interface:onText:"+ctx.session().uuid() + " said:" + ctx.message());
     }
 
     @Override
     public void onDisConnect(WebSocketContext ctx) {
-        System.out.println("ws from implements interface:onDisConnect:"+ctx.getSession().getUuid() + " disconnect");
+        System.out.println("ws from implements interface:onDisConnect:"+ctx.session().uuid() + " disconnect");
     }
 }

--- a/src/test/java/netty_hello/CustomWebSocketHandlerAnno.java
+++ b/src/test/java/netty_hello/CustomWebSocketHandlerAnno.java
@@ -14,6 +14,6 @@ public class CustomWebSocketHandlerAnno extends BaseWebSocketHandler {
 
     @OnMessage
     public void OnMessage(WebSocketContext ctx) {
-        System.out.println("ws from annotation @OnMessage:" + ctx.getSession().getUuid() + " said:" + ctx.getReqText());
+        System.out.println("ws from annotation @OnMessage:" + ctx.session().uuid() + " said:" + ctx.message());
     }
 }

--- a/src/test/java/netty_hello/WebSocketDemo.java
+++ b/src/test/java/netty_hello/WebSocketDemo.java
@@ -4,6 +4,8 @@ import com.blade.Blade;
 import com.blade.mvc.handler.WebSocketHandler;
 import com.blade.mvc.websocket.WebSocketContext;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author biezhi
  * @date 2017/10/30
@@ -17,18 +19,23 @@ public class WebSocketDemo {
                 .webSocket("/websocket", new WebSocketHandler() {
                     @Override
                     public void onConnect(WebSocketContext ctx) {
-                        System.out.println("客户端连接上了ws1: " + ctx.getSession());
+                        System.out.println(ctx.session().uuid()+":open");
+                        ctx.message(ctx.session().uuid()+":open");
                     }
 
                     @Override
                     public void onText(WebSocketContext ctx) {
-                        System.out.println("ws1收到:" + ctx.getReqText());
-                        ctx.message("发送: Hello");
+                        if("close".equals(ctx.message())){
+                            ctx.disconnect();
+                        } else {
+                            System.out.println(ctx.session().uuid()+":"+ctx.message());
+                            ctx.message(ctx.message());
+                        }
                     }
 
                     @Override
                     public void onDisConnect(WebSocketContext ctx) {
-                        System.out.println("ws1客户端关闭链接: " + ctx.getSession());
+                        System.out.println(ctx.session().uuid()+":close:" + ctx.session());
                     }
                 }).start(WebSocketDemo.class);
     }


### PR DESCRIPTION
Bug修复：websocket线程安全的问题
---
> Bug：之前将WebSocketContext做了缓存，而收到的消息是直接存放在WebSocketContext之中，导致如果在自己的方法中有比较耗时的操作此时又来一条消息的时候会覆盖之前的消息

如下面demo：
~~~java
//java服务端
public void onText(WebSocketContext ctx) {
    try {
        TimeUnit.SECONDS.sleep(1);
    } catch (InterruptedException e) {
        e.printStackTrace();
    }
    System.out.println(ctx.message());
}

//js 客户端 连续调用
var ws = new WebSocket('xxx');
ws.send('msg1');
ws.send('msg2');

//此时服务端会输出，导致第一条数据被覆盖丢失
msg2
msg2
~~~

---

调整：对现有WebSocketContext和WebSocketSession不兼容的破坏性修改
---
为了处理上述的bug，对context和session做了一些调整，会对现有的版本造成不兼容的修改
- context 中去除了`reqText`字段（去除了setReqText/getReqText），新增了`message`字段 （`message()`方法来获取消息）
  > 理由：因为不需要用户设置这个reqText，所以setter方法不需要，另外给ws发送消息用的是`message(String str)` 为了方便开发理解，因此干脆直接对应，加了个`message()`方法来获取ws接收到的消息
- context 构造做了相应修改，为了解决上述的bug，对用户无影响
- content 将`ChannelHandlerContext` 移动到 session中
- session 将`Channel`替换为`ChannelHandlerContext`
  > 理由：session中当前里面存放的`channel`没有起到任何作用，所以干脆将之前context中的`ChannelHandlerContext` 移动到 session中，毕竟如果需要channel可以直接从`ChannelHandlerContext`中获取
- session 对现有的 getter/setter 改为了目前比较流行的 fluent（即`field()`是获取`field(xxx)`是设置） 方式 
- session 构造函数做了相应修改，对用户无影响

---

其他调整
---
- 将调用`WebsocketHandler`方法的地方都做了异步处理，方便支持如在`onOpen`事件中直接给用户发消息（之前因为是同步的，所以导致无法在`onOpen`事件处理中发送消息）
- 将`WebSocketHandlerWrapper`中`ThreadLocal`修改为`FastThreadLocal`（我也不知道有没有用）
- `WebSocketContext` 中增加 `disconnect`方法，支持在服务端直接主动断开websocket连接