### PR TITLE
Auto lookup call class

### DIFF
--- a/src/main/java/com/blade/Blade.java
+++ b/src/main/java/com/blade/Blade.java
@@ -24,6 +24,7 @@ import com.blade.kit.Assert;
 import com.blade.kit.BladeKit;
 import com.blade.kit.JsonKit;
 import com.blade.kit.StringKit;
+import com.blade.kit.UncheckedFnKit;
 import com.blade.kit.reload.FileChangeDetector;
 import com.blade.loader.BladeLoader;
 import com.blade.mvc.handler.*;
@@ -832,8 +833,14 @@ public class Blade {
      *
      * @return return blade instance
      */
-    public Blade start() {
-        return this.start(null, null);
+    public Blade start(String... args) {
+        Class caller = Arrays.stream(Thread.currentThread().getStackTrace())
+                .filter(st -> "main".equals(st.getMethodName()))
+                .findFirst()
+                .map(StackTraceElement::getClassName)
+                .map(UncheckedFnKit.function(Class::forName))
+                .orElse(null);
+        return this.start(caller, args);
     }
 
     /**

--- a/src/main/java/com/blade/kit/UncheckedFnKit.java
+++ b/src/main/java/com/blade/kit/UncheckedFnKit.java
@@ -1,0 +1,90 @@
+package com.blade.kit;
+
+import com.blade.exception.BladeException;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * @author darren
+ * @date 2019/3/18 11:47
+ */
+public class UncheckedFnKit {
+
+    @FunctionalInterface
+    public interface Consumer_WithExceptions<T, E extends Throwable> {
+        void accept(T t) throws E;
+    }
+
+    @FunctionalInterface
+    public interface BiConsumer_WithExceptions<T, U, E extends Throwable> {
+        void accept(T t, U u) throws E;
+    }
+
+    @FunctionalInterface
+    public interface Function_WithExceptions<T, R, E extends Throwable> {
+        R apply(T t) throws E;
+    }
+
+    @FunctionalInterface
+    public interface Supplier_WithExceptions<T, E extends Throwable> {
+        T get() throws E;
+    }
+
+    @FunctionalInterface
+    public interface Runnable_WithExceptions<E extends Throwable> {
+        void run() throws E;
+    }
+
+    public static <T> Consumer<T> consumer(Consumer_WithExceptions<T, Throwable> consumer) {
+        return t -> {
+            try {
+                consumer.accept(t);
+            } catch (Throwable throwable) {
+                throw new BladeException(throwable);
+            }
+        };
+    }
+
+    public static <T, U> BiConsumer<T, U> biConsumer(BiConsumer_WithExceptions<T, U, Throwable> biConsumer) {
+        return (t, u) -> {
+            try {
+                biConsumer.accept(t, u);
+            } catch (Throwable throwable) {
+                throw new BladeException(throwable);
+            }
+        };
+    }
+
+    public static <T, R> Function<T, R> function(Function_WithExceptions<T, R, Throwable> function) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Throwable throwable) {
+                throw new BladeException(throwable);
+            }
+        };
+    }
+
+    public static <T> Supplier<T> supplier(Supplier_WithExceptions<T, Throwable> function) {
+        return () -> {
+            try {
+                return function.get();
+            } catch (Throwable throwable) {
+                throw new BladeException(throwable);
+            }
+        };
+    }
+
+    public static Runnable runnable(Runnable_WithExceptions t) {
+        return ()-> {
+            try {
+                t.run();
+            } catch (Throwable throwable) {
+                throw new BladeException(throwable);
+            }
+        };
+    }
+}


### PR DESCRIPTION
使用`blade.start()`方法时，自动获取调用的入口main方法的类

有些不严谨，比如如果自己写个方法，方法名也叫main的话，则读取的是自己定义的main方法，而不是程序入口main方法