### PR TITLE
fix https://github.com/lets-blade/blade/issues/377

### DIFF
--- a/src/main/java/com/blade/kit/CaseInsensitiveHashMap.java
+++ b/src/main/java/com/blade/kit/CaseInsensitiveHashMap.java
@@ -1,0 +1,88 @@
+package com.blade.kit;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class CaseInsensitiveHashMap<V> extends LinkedHashMap<String, V> {
+
+    private final Map<String, String> KEY_MAPPING;
+
+    public CaseInsensitiveHashMap() {
+        super();
+        KEY_MAPPING = new HashMap<>();
+    }
+
+    public CaseInsensitiveHashMap(int initialCapacity) {
+        super(initialCapacity);
+        KEY_MAPPING = new HashMap<>(initialCapacity);
+    }
+
+    public CaseInsensitiveHashMap(int initialCapacity, float loadFactor) {
+        super(initialCapacity, loadFactor);
+        this.KEY_MAPPING = new HashMap<>(initialCapacity);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return super.containsKey(realKey(key));
+    }
+
+    @Override
+    public V get(Object key) {
+        return super.get(realKey(key));
+    }
+
+    @Override
+    public V put(String key, V value) {
+        if (key == null) {
+            return super.put(null, value);
+        } else {
+            String oldKey   = KEY_MAPPING.put(key.toLowerCase(Locale.ENGLISH), key);
+            V      oldValue = super.remove(oldKey);
+            super.put(key, value);
+            return oldValue;
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends V> m) {
+        m.forEach(this::put);
+    }
+
+    @Override
+    public V remove(Object key) {
+        Object realKey;
+        if (key != null) {
+            realKey = KEY_MAPPING.remove(key.toString().toLowerCase(Locale.ENGLISH));
+        } else {
+            realKey = null;
+        }
+        return super.remove(realKey);
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        //当 lowerCaseMap 中不包含当前key时直接返回默认值
+        if (key != null && !KEY_MAPPING.containsKey(key.toString().toLowerCase(Locale.ENGLISH))) {
+            return defaultValue;
+        }
+        //转换key之后从super中获取值
+        return super.getOrDefault(realKey(key), defaultValue);
+    }
+
+    @Override
+    public void clear() {
+        KEY_MAPPING.clear();
+        super.clear();
+    }
+
+    private Object realKey(Object key) {
+        if (key != null) {
+            return KEY_MAPPING.get(key.toString().toLowerCase(Locale.ENGLISH));
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/blade/mvc/http/HttpRequest.java
+++ b/src/main/java/com/blade/mvc/http/HttpRequest.java
@@ -16,6 +16,7 @@
 package com.blade.mvc.http;
 
 import com.blade.exception.HttpParseException;
+import com.blade.kit.CaseInsensitiveHashMap;
 import com.blade.kit.PathKit;
 import com.blade.kit.StringKit;
 import com.blade.mvc.Const;
@@ -28,9 +29,21 @@ import com.blade.server.netty.HttpConst;
 import com.blade.server.netty.HttpServerHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
-import io.netty.handler.codec.http.multipart.*;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.handler.codec.http.multipart.DiskAttribute;
+import io.netty.handler.codec.http.multipart.DiskFileUpload;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.util.CharsetUtil;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -42,7 +55,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 
 /**
  * Http Request Impl
@@ -262,11 +281,9 @@ public class HttpRequest implements Request {
     @Override
     public Map<String, String> headers() {
         if (null == headers) {
-            headers = new HashMap<>(httpHeaders.size());
-            Iterator<Map.Entry<String, String>> entryIterator = httpHeaders.iteratorAsString();
-            while (entryIterator.hasNext()) {
-                Map.Entry<String, String> next = entryIterator.next();
-                headers.put(next.getKey(), next.getValue());
+            headers = new CaseInsensitiveHashMap<>(httpHeaders.size());
+            for (Map.Entry<String, String> header : httpHeaders) {
+                headers.put(header.getKey(), header.getValue());
             }
         }
         return this.headers;

--- a/src/main/java/com/blade/mvc/http/Request.java
+++ b/src/main/java/com/blade/mvc/http/Request.java
@@ -423,13 +423,7 @@ public interface Request {
      * @return Return header information
      */
     default String header(@NonNull String name) {
-        String header = "";
-        if (headers().containsKey(name)) {
-            header = headers().get(name);
-        } else if (headers().containsKey(name.toLowerCase())) {
-            header = headers().get(name.toLowerCase());
-        }
-        return header;
+        return headers().getOrDefault(name,"");
     }
 
     /**

--- a/src/test/java/com/blade/BaseTestCase.java
+++ b/src/test/java/com/blade/BaseTestCase.java
@@ -1,5 +1,6 @@
 package com.blade;
 
+import com.blade.mvc.WebContext;
 import com.blade.mvc.http.HttpMethod;
 import com.blade.mvc.http.Response;
 import com.mashape.unirest.http.Unirest;
@@ -23,6 +24,7 @@ public class BaseTestCase {
     protected String firefoxUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:53.0) Gecko/20100101 Firefox/53.0";
 
     protected com.blade.mvc.http.HttpRequest mockHttpRequest(String methodName) {
+        WebContext.init(Blade.of(),"/");
         com.blade.mvc.http.HttpRequest request = mock(com.blade.mvc.http.HttpRequest.class);
         when(request.method()).thenReturn(methodName);
         when(request.url()).thenReturn("/");

--- a/src/test/java/com/blade/mvc/HttpRequestTest.java
+++ b/src/test/java/com/blade/mvc/HttpRequestTest.java
@@ -1,22 +1,24 @@
 package com.blade.mvc;
 
 import com.blade.BaseTestCase;
+import com.blade.kit.CaseInsensitiveHashMap;
 import com.blade.mvc.http.Cookie;
 import com.blade.mvc.http.HttpMethod;
 import com.blade.mvc.http.HttpRequest;
 import com.blade.mvc.http.Request;
 import com.blade.mvc.multipart.FileItem;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -256,16 +258,19 @@ public class HttpRequestTest extends BaseTestCase {
     @Test
     public void testHeaders() {
         Request             mockRequest = mockHttpRequest("GET");
-        Map<String, String> headers     = new HashMap<>();
+        Map<String, String> headers     = new CaseInsensitiveHashMap<>();
         headers.put("h1", "a1");
-        headers.put("h2", "a2");
+        headers.put("H2", "a2");
 
         when(mockRequest.headers()).thenReturn(headers);
 
         Request request = new HttpRequest(mockRequest);
 
         assertEquals("a1", request.header("h1"));
+        assertEquals("a1", request.header("H1"));
         assertEquals("a2", request.header("h2"));
+        assertEquals("a2", request.header("H2"));
+        request.headers().forEach((key,val)-> System.out.println(key+"\t=\t"+val));
     }
 
     @Test


### PR DESCRIPTION
添加一个CaseInsensitiveHashMap
> 让headers的Map不再大小写敏感的同时也能原样迭代输出用户原始的Headers的key信息。