### PR TITLE
修复可能存在OOM的问题

### DIFF
--- a/src/main/java/com/blade/kit/LRUSet.java
+++ b/src/main/java/com/blade/kit/LRUSet.java
@@ -1,0 +1,56 @@
+package com.blade.kit;
+
+import java.util.*;
+
+/**
+ * @author darren
+ * @date 2019/10/16 13:39
+ */
+public class LRUSet<E> extends AbstractSet<E>{
+    private transient    HashMap<E, Object> map;
+    private static final Object             PRESENT = new Object();
+
+    public LRUSet(int capacity) {
+        this.map = new LinkedHashMap<E, Object>(Math.min(32,capacity), .75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry eldest) {
+                return size() > capacity;
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return map.get(o) == PRESENT;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return map.keySet().iterator();
+    }
+
+    @Override
+    public boolean add(E e) {
+        return map.put(e, PRESENT) == null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return map.remove(o) == PRESENT;
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+}


### PR DESCRIPTION
修复可能存在OOM的问题 
> https://github.com/lets-blade/blade/issues/380

解决思路是使用LinkedHashMap的removeEldestEntry实现了一个类似于LRUCache的自定义LRUSet类来替代原来的HashSet类，LRUSet设定最大的容量（当前为128），当往set中put新数据超过了最大容量时，会自动删除不常用的记录，每一次contains判断都会激活一次记录，这样能保证在notStaticUri 中的URI都是一些最新的热点记录，又不会因为比如动态URL path导致的无限制增长