### PR TITLE
修复当启动类没有包名时空指针的bug

### DIFF
--- a/src/main/java/com/blade/server/netty/NettyServer.java
+++ b/src/main/java/com/blade/server/netty/NettyServer.java
@@ -73,6 +73,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -373,9 +374,10 @@ public class NettyServer implements Server {
 
     private void initConfig() {
 
-        if (null != blade.bootClass()) {
-            blade.scanPackages(blade.bootClass().getPackage().getName());
-        }
+        Optional.ofNullable(blade.bootClass())
+                .map(Class::getPackage)
+                .map(Package::getName)
+                .ifPresent(blade::scanPackages);
 
         // print banner text
         this.printBanner();

--- a/src/test/java/PkgNpeTest.java
+++ b/src/test/java/PkgNpeTest.java
@@ -1,0 +1,13 @@
+import com.blade.Blade;
+
+/**
+ * @author darren
+ * @date 2019/10/16 16:59
+ */
+public class PkgNpeTest {
+
+    public static void main(String[] args) {
+        Blade.of()
+                .start();
+    }
+}


### PR DESCRIPTION
当启动类放在根目录下，没有package时获取getPackage返回值为null，此时调用package.getName会报空指针