### PR TITLE
Fix webjars when file is null

### DIFF
--- a/blade-core/src/main/java/com/hellokaton/blade/server/StaticFileHandler.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/server/StaticFileHandler.java
@@ -446,8 +446,10 @@ public class StaticFileHandler implements RequestHandler {
 
             response.headers().set(HttpHeaderNames.EXPIRES, dateFormatter.format(time.getTime()));
             response.headers().set(HttpHeaderNames.CACHE_CONTROL, "private, max-age=" + staticFileCacheSeconds);
-            response.headers().set(
-                    HttpHeaderNames.LAST_MODIFIED, dateFormatter.format(new Date(fileToCache.lastModified())));
+            if(null!=fileToCache){
+                response.headers().set(
+                        HttpHeaderNames.LAST_MODIFIED, dateFormatter.format(new Date(fileToCache.lastModified())));
+            }
         }
     }
 


### PR DESCRIPTION
Add a webjars dependency for example:

```
<dependency>
        <groupId>org.webjars</groupId>
        <artifactId>jquery</artifactId>
        <version>3.6.1</version>
</dependency>
```

Now verify the lib adding the script into a HTML page: `<script src="/webjars/jquery/3.6.1/jquery.min.js"></script>`
In the console we see:
![image](https://user-images.githubusercontent.com/14241204/196491965-5b537a7e-eabc-4869-8425-f4b2abfd1afc.png)


<!--
Thanks for contributing to Blade. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->