### PR TITLE
Test Fix: Fix a test that can unintentionally fail in testAddStatics()

### DIFF
--- a/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
@@ -125,8 +125,7 @@ public class BladeTest extends BaseTestCase {
             options.addStatic("/assets/");
             options.addStatic("/assets/");
         });
-
-        assertEquals(7, blade.staticOptions().getPaths().size());
+        assertEquals(5, blade.staticOptions().getPaths().size());
         assertEquals(Boolean.TRUE, blade.staticOptions().getPaths().contains("/assets/"));
         assertEquals(Boolean.FALSE, blade.staticOptions().getPaths().contains("/hello/"));
     }

--- a/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
@@ -125,7 +125,7 @@ public class BladeTest extends BaseTestCase {
             options.addStatic("/assets/");
             options.addStatic("/assets/");
         });
-        
+
         assertEquals(5, blade.staticOptions().getPaths().size());
         assertEquals(Boolean.TRUE, blade.staticOptions().getPaths().contains("/assets/"));
         assertEquals(Boolean.FALSE, blade.staticOptions().getPaths().contains("/hello/"));

--- a/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java
@@ -125,6 +125,7 @@ public class BladeTest extends BaseTestCase {
             options.addStatic("/assets/");
             options.addStatic("/assets/");
         });
+        
         assertEquals(5, blade.staticOptions().getPaths().size());
         assertEquals(Boolean.TRUE, blade.staticOptions().getPaths().contains("/assets/"));
         assertEquals(Boolean.FALSE, blade.staticOptions().getPaths().contains("/hello/"));


### PR DESCRIPTION
The StaticOptions class uses a `Set<String>` for paths, meaning no duplicate values can exist, which makes sense as static paths should be unique (please correct me if I'm mistaken). It seems that the length of DEFAULT_STATICS is only 4, as seen in [line 16 of StaticOptions](https://github.com/lets-blade/blade/blob/aa32ce91386f491a3d0cb174beb190be1505ca27/blade-core/src/main/java/com/hellokaton/blade/options/StaticOptions.java#L16). Therefore, after trying to add two repeated static paths, the expected length of paths should be 5 (4 + 1) rather than 7.

Below is an example where it fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) on [line 129](https://github.com/lets-blade/blade/blob/aa32ce91386f491a3d0cb174beb190be1505ca27/blade-core/src/test/java/com/hellokaton/blade/BladeTest.java#L129)


<details>

<summary>Click on to see more details on the error message when running this test</summary>

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Concurrency config is parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running com.hellokaton.blade.BladeTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.106 sec <<< FAILURE!
testAddStatics(com.hellokaton.blade.BladeTest)  Time elapsed: 0.004 sec  <<< FAILURE!
java.lang.AssertionError: expected:<7> but was:<5>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at com.hellokaton.blade.BladeTest.testAddStatics(BladeTest.java:129)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.junit.runners.Suite.runChild(Suite.java:128)
        at org.junit.runners.Suite.runChild(Suite.java:27)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
        at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
        at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)


Results :

Failed tests:   testAddStatics(com.hellokaton.blade.BladeTest): expected:<7> but was:<5>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

</details>

To reproduce, run this at the root directory:

```
mvn -pl blade-core     edu.illinois:nondex-maven-plugin:2.1.7:nondex     -Dtest=com.hellokaton.blade.BladeTest#testAddStatics -DnondexRuns=10
```
(Note: We are running the test 10 times using -DnondexRuns=10, and it should fail each time.)

The log output can be found here for your reference:
[mvn-nondex-2-1729138783.log](https://github.com/user-attachments/files/17406043/mvn-nondex-2-1729138783.log)

To resolve this, we can simply adjust the expected value to 5

After applying the fix, the test should now pass with NonDex as expected:

```
[INFO] *********
[INFO] All tests pass without NonDex shuffling
[INFO] ####################
[INFO] Across all seeds:
[INFO] Test results can be found at: 
[INFO] file:///home/jakew4/blade/blade-core/.nondex/hiGUvHUAJW5qmg+1sjvtmshPu2bJkyPI4Pc9BG698=/test_results.html
[INFO] [NonDex] The id of this run is: hiGUvHUAJW5qmg+1sjvtmshPu2bJkyPI4Pc9BG698=
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.580 s
[INFO] Finished at: 2024-10-16T23:24:58-05:00
[INFO] ------------------------------------------------------------------------
```

Please let me know if this approach works for you. If not, I'm happy to discuss alternatives and am willing to spend more time to address the test in the way you'd prefer. Thank you!