### PR TITLE
add a test to validate important scenarios.

### DIFF
--- a/blade-kit/src/test/java/com/hellokaton/blade/kit/BCryptTest.java
+++ b/blade-kit/src/test/java/com/hellokaton/blade/kit/BCryptTest.java
@@ -174,4 +174,17 @@ public class BCryptTest {
         System.out.println("");
     }
 
+    /**
+     * Test for correct handling of corrupted hashes
+     * expecting failure
+     */
+    @Test
+    public void testCheckpw_failure_modifiedAndTruncatedHash() {
+        String plain = test_vectors[0][0];
+        String expected = test_vectors[0][2];
+        String corruptedHash = expected.substring(0, 15) + "Q" + expected.substring(15);
+        String truncatedHash = expected.substring(0, expected.length() - 5);
+        Assert.assertFalse(BCrypt.checkpw(plain, corruptedHash));
+        Assert.assertFalse(BCrypt.checkpw(plain, truncatedHash));
+    }
 }


### PR DESCRIPTION
I noticed that the `checkpw` method in `com.hellokaton.blade.kit.BCrypt` is not fully tested. Specifically, the current test suite does not cover the branch `if (hashed_bytes.length != try_bytes.length)`, which handles scenarios where the stored password hashes may be corrupted. These scenarios are important to consider, as real-world issues—often introduced during database migrations or system updates—can lead to such inconsistencies.

To address this gap, I’ve added a test that explicitly validates this scenario. I hope it proves helpful in detecting potential regressions.

If additional test coverage would be valuable, I’d be happy to contribute further by looking into other classes you consider important for a follow-up PR.